### PR TITLE
Script v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This script does **not** alter file integrity, never sends data off the nodes it
 • dialog  
 • root privileges  
 
-## Installation (single-line)
+## Usage (single-line)
 
-Run this on any Proxmox node to download & execute the latest version:  
+Run this on any Proxmox node (that contains your vmid) to download & execute the latest version:  
 
 ```
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/sannier3/proxmox-vmid-updater/main/rename-vmid.sh)"
@@ -30,7 +30,7 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/sannier3/proxmox-vmid-up
 
 1. Become root (`sudo -i` or `su –`) 
 2. Paste the installation command above 
-3. Follow dialogs to select “qemu” or “lxc”, enter old and new VMID, confirm shutdown and summary  
+3. Follow dialogs enter old and new VMID, confirm shutdown and summary  
 4. On confirmation, the VMID is migrated everywhere
 
 ## Supported storage types

--- a/rename-vmid.sh
+++ b/rename-vmid.sh
@@ -225,7 +225,7 @@ log "Storages: ${ACTIVE_STORAGES[*]}"
 ### 9) Gather block volumes from the main section
 mapfile -t VOL_OLD < <(
   sed '/^\[/{q}' "$CONF_PATH" \
-    | grep -E '^(scsi|ide|virtio|sata|efidisk|tpmstate|unused)[0-9]+:' \
+    | grep -E '^(scsi|ide|virtio|sata|efidisk|tpmstate|unused)[0-9]+:|^(rootfs|mp[0-9]+):' \
     | sed -E 's/^[^:]+:[[:space:]]*//' \
     | cut -d',' -f1
 )
@@ -311,8 +311,10 @@ SUMMARY=/tmp/rename_summary.txt
     suffix=${old_snap#snap_vm-${ID_OLD}-disk-}
     echo "    $vg/$old_snap → $vg/snap_vm-${ID_NEW}-disk-${suffix}"
   done
-  echo; echo "• File volumes:"
-  for vf in "${FILE_OLD[@]}"; do echo "    $vf"; done
+  echo; echo "• Disques et points de montage (file-based):"
+  for vf in "${FILE_OLD[@]}"; do
+    echo "    $vf"
+  done
   echo; echo "• Snapshots (sections):"
   for s in "${SNAP_SECTIONS[@]}"; do echo "    [$s]"; done
   echo; echo "• VMSTATE entries:"

--- a/rename-vmid.sh
+++ b/rename-vmid.sh
@@ -53,66 +53,64 @@ USE AT YOUR OWN RISK!" 14 70
 ### 2) Determine cluster nodes (or single node)
 CLUSTER_NODES=()
 if pvecm nodes &>/dev/null; then
-  # fetch node list via API, extract "node" fields from JSON
+  # Fetch node list via API, extract "node" fields from JSON
   mapfile -t CLUSTER_NODES < <(
     pvesh get /nodes --output-format=json 2>/dev/null \
       | grep -Po '"node"\s*:\s*"\K[^"]+'
   )
   log "Cluster nodes: ${CLUSTER_NODES[*]}"
 else
-  # standalone mode: only the current host
+  # Standalone mode: only the local host
   THIS_NODE=$(hostname)
   CLUSTER_NODES=("$THIS_NODE")
   log "Not in a cluster, using local node: $THIS_NODE"
 fi
 
-### 3) Prompt for old VMID, detect type and host node, ensure running on correct node
+### 3) Prompt for old VMID, detect TYPE and host node (direct lookup)
 while true; do
   ID_OLD=$(dialog --stdout --inputbox "Enter current VMID (ESC to quit):" 8 50) || exit 1
   log "Step 3: User entered old VMID: $ID_OLD"
   [[ -n "$ID_OLD" ]] || { log "Step 3: Empty VMID entered, retrying"; dialog --msgbox "Empty ID!" 6 40; continue; }
 
   NODE_ASSIGNED=""
-  log "Step 3: Scanning for VMID $ID_OLD on nodes: ${CLUSTER_NODES[*]}"
-
-  # check QEMU VMs on each node
+  # Try direct QEMU lookup
   for N in "${CLUSTER_NODES[@]}"; do
-    log "Step 3: Checking QEMU VMs on node $N"
-    if pvesh get "/nodes/$N/qemu-server" --output-format=json 2>/dev/null \
-       | grep -q "\"vmid\"[[:space:]]*:[[:space:]]*$ID_OLD"; then
+    log "Step 3: Checking QEMU VM $ID_OLD on node $N"
+    if pvesh get "/nodes/$N/qemu-server/$ID_OLD" &>/dev/null; then
       TYPE=qemu
       NODE_ASSIGNED=$N
-      log "Step 3: Found QEMU VM $ID_OLD on node $N"
+      log "Step 3: Found QEMU VM $ID_OLD on $N"
       break
+    else
+      log "Step 3: QEMU VM $ID_OLD not on node $N"
     fi
-    log "Step 3: QEMU VM $ID_OLD not on node $N"
   done
 
-  # if not found as QEMU, check LXC containers
+  # If not found as QEMU, try direct LXC lookup
   if [[ -z "$NODE_ASSIGNED" ]]; then
     for N in "${CLUSTER_NODES[@]}"; do
-      log "Step 3: Checking LXC containers on node $N"
-      if pvesh get "/nodes/$N/lxc" --output-format=json 2>/dev/null \
-         | grep -q "\"vmid\"[[:space:]]*:[[:space:]]*$ID_OLD"; then
+      log "Step 3: Checking LXC CT $ID_OLD on node $N"
+      if pvesh get "/nodes/$N/lxc/$ID_OLD" &>/dev/null; then
         TYPE=lxc
         NODE_ASSIGNED=$N
-        log "Step 3: Found LXC CT $ID_OLD on node $N"
+        log "Step 3: Found LXC CT $ID_OLD on $N"
         break
+      else
+        log "Step 3: LXC CT $ID_OLD not on node $N"
       fi
-      log "Step 3: LXC CT $ID_OLD not on node $N"
     done
   fi
 
-  # if still not found, ask again
+  # If still not found, prompt again
   if [[ -z "$NODE_ASSIGNED" ]]; then
     log "Step 3: VMID $ID_OLD not found on any node"
     dialog --msgbox "VMID $ID_OLD not found on any node." 6 50
     continue
   fi
 
-  # ensure script is running on the host node
+  # Ensure we’re on the correct node
   LOCAL_NODE=$(hostname)
-  log "Step 3: VMID $ID_OLD assigned to node $NODE_ASSIGNED; script running on $LOCAL_NODE"
+  log "Step 3: VMID $ID_OLD is on node $NODE_ASSIGNED; script running on $LOCAL_NODE"
   if [[ "$NODE_ASSIGNED" != "$LOCAL_NODE" ]]; then
     dialog --msgbox "\
 VMID $ID_OLD is hosted on node: $NODE_ASSIGNED

--- a/rename-vmid.sh
+++ b/rename-vmid.sh
@@ -432,7 +432,10 @@ for vol in "${FILE_OLD[@]}"; do
   newf="${ST_PATH[$st]}/images/$ID_NEW/$(basename "${rel//$ID_OLD/$ID_NEW}")"
   if [[ -f "$oldf" ]]; then
     mv "$oldf" "$newf"
-    sed -i "s|$st:$rel|$st:${rel//$ID_OLD/$ID_NEW}|g" "$CONF_DIR/$ID_NEW.conf"
+    escaped_st=$(printf '%s' "$st" | sed 's/[&/\]/\\&/g')
+    escaped_rel=$(printf '%s' "$rel" | sed 's/[&/\]/\\&/g')
+    escaped_rel_new=$(printf '%s' "${rel//$ID_OLD/$ID_NEW}" | sed 's/[&/\]/\\&/g')
+    sed -i "s|$escaped_st:$escaped_rel|$escaped_st:$escaped_rel_new|g" "$CONF_DIR/$ID_NEW.conf"
     log "File: $oldf → $newf"
   else
     log "⚠️  File not found, skipped: $oldf"

--- a/rename-vmid.sh
+++ b/rename-vmid.sh
@@ -69,9 +69,9 @@ while true; do
 
   NODE_ASSIGNED=""
   for N in "${CLUSTER_NODES[@]}"; do
-    if pvesh get "/nodes/$N/qemu-server/$ID_OLD" &>/dev/null; then
+    if pvesh get "/nodes/$N/qemu-server/$ID_OLD" --output-format=json &>/dev/null; then
       TYPE=qemu; NODE_ASSIGNED=$N; break
-    elif pvesh get "/nodes/$N/lxc/$ID_OLD" &>/dev/null; then
+    elif pvesh get "/nodes/$N/lxc/$ID_OLD" --output-format=json &>/dev/null; then
       TYPE=lxc; NODE_ASSIGNED=$N; break
     fi
   done

--- a/rename-vmid.sh
+++ b/rename-vmid.sh
@@ -110,9 +110,9 @@ while true; do
     continue
   fi
 
-  # ensure we’re on the correct node
-  LOCAL_NODE=$(hostname)
-  log "Step 3: VMID $ID_OLD is on node $NODE_ASSIGNED; script running on $LOCAL_NODE"
+    # ensure we’re on the correct node (use short hostname to match Proxmox node names)
+  LOCAL_NODE=$(hostname -s)
+  log "Step 3: VMID $ID_OLD is on node $NODE_ASSIGNED; local short hostname is $LOCAL_NODE"
   if [[ "$NODE_ASSIGNED" != "$LOCAL_NODE" ]]; then
     dialog --msgbox "\
 VMID $ID_OLD is hosted on node: $NODE_ASSIGNED

--- a/rename-vmid.sh
+++ b/rename-vmid.sh
@@ -113,17 +113,7 @@ if [[ -z "$NODE_ASSIGNED" ]]; then
 fi
 log "Host node: $NODE_ASSIGNED"
 
-### 7) Retrieve VM/LXC name
-if [[ "$TYPE" == qemu ]]; then
-  NAME=$(pvesh get /nodes/$NODE_ASSIGNED/qemu-server/$ID_OLD --output-format=json \
-         | grep -Po '"name"\s*:\s*"\K[^"]+' || echo "unknown")
-else
-  NAME=$(pvesh get /nodes/$NODE_ASSIGNED/lxc/$ID_OLD --output-format=json \
-         | grep -Po '"hostname"\s*:\s*"\K[^"]+' || echo "unknown")
-fi
-log "Name: $NAME"
-
-### 8) Locate config file
+### 7) Locate config file
 if [[ "$TYPE" == qemu ]]; then
   CONF_PATH="/etc/pve/nodes/$NODE_ASSIGNED/qemu-server/$ID_OLD.conf"
 else
@@ -135,6 +125,10 @@ if [[ ! -f "$CONF_PATH" ]]; then
 fi
 CONF_DIR=$(dirname "$CONF_PATH")
 log "Config: $CONF_PATH"
+
+### 8) Retrieve VM/LXC name from config
+NAME=$(grep -E '^name:' "$CONF_PATH" | head -n1 | awk '{print $2}' || echo "unknown")
+log "Name: $NAME"
 
 ### 9) Stop instance if needed
 if [[ "$TYPE" == qemu ]]; then


### PR DESCRIPTION
# Changelog pour proxmox-vmid-updater

## \[Unreleased] 2025-05-12

### Nouvelles fonctionnalités

* **Détection automatique du type** de VM/CT (QEMU vs LXC) en interrogeant directement `/nodes/<node>/qemu/<vmid>/config` ou `/lxc/<vmid>/config`, plus besoin du menu manuel « What to rename? ».
* **Proposition du prochain VMID disponible** si l’ID saisi est déjà occupé, avec affichage du nom et du type (QEMU/LXC) de l’instance existante.
* **Extraction du nom de la VM/CT** (champ `name:` dans le fichier de config) pour l’inclure dans le résumé et les messages de confirmation.
* **Validation du nœud d’exécution** : si l’utilisateur lance le script sur un autre nœud que celui qui héberge la VMID, un message l’invite à se reconnecter sur le bon nœud.
* **Support « standalone »** et **mode cluster** unifiés :

  * Récupération de la liste des nœuds via `pvesh get /nodes`.
  * Cas non-clusterisés détecté automatiquement, avec fallback sur `hostname`.

### Améliorations & renforcement des vérifications

* **Vérification avancée du nouvel ID** :

  * Contrôle sur tous les nœuds (`qemu` puis `lxc`).
  * Affichage d’une infobox détaillée en cas de conflit (nom, type, nœud).
* **Logging ultra-verbeux** : horodatage et description claire de chaque action, facilitant le débogage.
* **Installation automatique des dépendances** (`dialog`, `pvesh`, `pvecm`, `pvesm`) si absentes.
* **Messages d’avertissement** plus visibles (dialog box “⚠️ USE AT YOUR OWN RISK!”).
* **Utilisation de `hostname -s`** pour comparer les noms courts de nœuds (plus fiable dans certains environnements).

### Robustesse & sécurité

* **Vérification des retours d’erreur** (`mv`, `lvrename`, etc.) : chaque opération est testée avant exécution, et un log “⚠️ … skipped” est émis en cas de fichier/volume manquant.
* **Aucune donnée n’est exfiltrée** : tout passe par les API locales Proxmox et la CLI, rien n’est envoyé hors du cluster.
* **Tests manuels réalisés** :

  * Scénarios multi-nœuds et standalone.
  * VMID libre, VMID occupé par QEMU et LXC.
  * Volumes LVM et file-based (NFS, CIFS, GlusterFS).
  * Snapshots LVM présents et absents.
  * Rollback partiel en cas d’échec d’arrêt ou d’opération de renommage.

### Nettoyage & refactoring

* Regroupement des boucles de détection et validation des VMID (moins de duplication).
* Uniformisation de la récupération des volumes block vs file.
* Suppression du menu de sélection du type (étape 2 obsolète).
* Renumérotation claire des étapes dans les commentaires (`### 2) …`, `### 3) …`, etc.).
* Simplification de la génération du résumé (inclusion du nom, LVM snapshots, backups, jobs, ACL).
