### PR TITLE
v1.3.0 - Production hardening: transactional rollback, safety gates, Ceph/RBD & HA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PROXMOX-VMID-UPDATER  v1.2.0
+# PROXMOX-VMID-UPDATER  v1.3.0
 
 Interactive Bash script to safely rename a QEMU VM or LXC container VMID on Proxmox VE, with:
 
@@ -10,15 +10,29 @@ Interactive Bash script to safely rename a QEMU VM or LXC container VMID on Prox
   Move `/etc/pve/.../<old>.conf` → `<new>.conf`.
 * **Storage updates**
 
-  * **LVM** volumes (via `lvrename` + config update)
-  * **ZFS** datasets & snapshots (via `zfs rename` + config update)
+  * **LVM** volumes (via `lvrename` + config update), incl. templates (`base-*`) and cloud-init drives
+  * **ZFS** datasets & snapshots (via `zfs rename` + config update), incl. linked clones
+  * **Ceph/RBD** images (via `rbd rename` + config update)
   * **File-based** images under `…/images/<VMID>/…` (local FS, NFS, CIFS, GlusterFS, CephFS)
+  * **Bind/device mount points** (e.g. `mp0: /mnt/storage`) are detected and left untouched
 * **Snapshot & vmstate** entries
   Renamed both in the config file and on disk.
 * **Backups & jobs**
   Rename `vzdump`, replication logs and entries to use the new VMID.
 * **Pools & ACLs**
   Update `/etc/pve/user.cfg` cluster-wide.
+* **HA & firewall**
+  Temporarily disable the HA resource (so the CRM can't restart the guest mid-rename),
+  update `/etc/pve/ha/resources.cfg`, restore its original state, and rename per-guest
+  `/etc/pve/firewall/<VMID>.fw`.
+* **Pre-flight safety gates** (abort cleanly, change nothing)
+  * a disk or saved state on an **offline/disabled storage**;
+  * a **template that still has linked clones**;
+  * an existing **replication job** for the guest.
+* **Transactional apply with rollback**
+  The original config is kept untouched until every volume rename succeeds; on any
+  failure all renames are reverted automatically. Existing target files are never
+  overwritten.
 * **Full logging**
   All operations timestamped to console and `rename-vmid.sh.log`.
 
@@ -26,7 +40,7 @@ Interactive Bash script to safely rename a QEMU VM or LXC container VMID on Prox
 
 ## Prerequisites
 
-* **Proxmox VE 6.x / 7.x**
+* **Proxmox VE 8.x or newer**
   (commands: `bash`, `pvesh`, `pvecm`, `pvesm`, `qm`, `pct`)
 * **dialog**
 * **Root** privileges
@@ -36,7 +50,7 @@ Interactive Bash script to safely rename a QEMU VM or LXC container VMID on Prox
 ## Quick Run
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/sannier3/proxmox-vmid-updater/main/rename-vmid.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/sannier3/proxmox-vmid-updater/dev/rename-vmid.sh)"
 ```
 
 Then follow the interactive prompts.
@@ -45,10 +59,14 @@ Then follow the interactive prompts.
 
 ## Supported Storage Types
 
-* **LVM** logical volumes
-* **ZFS** datasets & snapshots
+* **LVM** logical volumes (incl. templates `base-*` and cloud-init drives)
+* **ZFS** datasets & snapshots (incl. linked clones)
+* **Ceph/RBD** block images
 * **File-based** images under `storage/images/<VMID>/…`
   (treats NFS, CIFS, GlusterFS, CephFS mounts exactly like local files)
+
+> Bind/device mount points (LXC `mpX: /host/path`) and ISO/empty CD-ROM drives
+> are detected and skipped automatically.
 
 ---
 
@@ -67,7 +85,11 @@ Then follow the interactive prompts.
 * **No external connections**
   Uses only local Proxmox APIs and mounted filesystems.
 * **Read-only until confirmation**
-  Every destructive change is gated behind a “Yes/No” prompt.
+  Every destructive change is gated behind a “Yes/No” prompt, and risky scenarios
+  (offline storage, linked clones, replication) abort before anything is touched.
+* **Atomic & reversible**
+  Volume renames are tracked and rolled back automatically if any step fails; the
+  config is only committed once all renames succeed.
 * **Fully logged**
   All actions go into `rename-vmid.sh.log` in your current directory.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Interactive Bash script to safely rename a QEMU VM or LXC container VMID on Prox
 ## Quick Run
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/sannier3/proxmox-vmid-updater/dev/rename-vmid.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/sannier3/proxmox-vmid-updater/main/rename-vmid.sh)"
 ```
 
 Then follow the interactive prompts.

--- a/rename-vmid.sh
+++ b/rename-vmid.sh
@@ -322,7 +322,7 @@ while true; do
             break
           fi
         done
-        $BUSY && (( NEXT++ )) || break
+        if $BUSY; then (( NEXT++ )); else break; fi
       done
   
       dialog --msgbox "\
@@ -686,7 +686,7 @@ Nothing was changed." 12 74
     if dialog --yesno "Instance is '${STATE:-unknown}'. Stop it now?" 7 50; then
       log "Stopping $TYPE $ID_OLD"
       if [[ "$TYPE" == qemu ]]; then qm shutdown "$ID_OLD" || true; else pct shutdown "$ID_OLD" || true; fi
-      for i in {1..20}; do
+      for _ in {1..20}; do
         sleep 3
         if [[ "$TYPE" == qemu ]]; then STATE=$(qm status "$ID_OLD" 2>/dev/null | awk '{print $2}')
         else STATE=$(pct status "$ID_OLD" 2>/dev/null | awk '{print $2}'); fi

--- a/rename-vmid.sh
+++ b/rename-vmid.sh
@@ -13,6 +13,96 @@ log(){
   echo "$msg" | tee -a "$LOGFILE"
 }
 
+### ————————————————
+### Helpers
+
+# Rollback stack: each entry is a shell command that undoes a previous step.
+ROLLBACK=()
+push_rollback(){ ROLLBACK+=("$1"); }
+do_rollback(){
+  (( ${#ROLLBACK[@]} == 0 )) && return 0
+  log "⚠️  Rolling back ${#ROLLBACK[@]} change(s)…"
+  local i
+  for (( i=${#ROLLBACK[@]}-1; i>=0; i-- )); do
+    log "Rollback: ${ROLLBACK[$i]}"
+    eval "${ROLLBACK[$i]}" 2>>"$LOGFILE" || log "⚠️  Rollback step failed: ${ROLLBACK[$i]}"
+  done
+  ROLLBACK=()
+}
+
+# HA neutralization state for the current guest (used to restore on abort).
+HA_SID=""; HA_STATE="started"
+restore_ha(){
+  [[ -z "$HA_SID" ]] && return 0
+  if ha-manager set "$HA_SID" --state "$HA_STATE" &>/dev/null; then
+    log "Restored HA $HA_SID (state=$HA_STATE)"
+  else
+    log "⚠️  Could not restore HA $HA_SID"
+  fi
+}
+
+# Reason string if the guest is busy, else empty + return 1 (idle).
+# "Busy" = the config holds a "lock:" (set by backup/migrate/snapshot/clone/
+# move-disk/rollback…) OR a task is actively running against this guest.
+# Renaming underneath any of these would corrupt the in-flight operation.
+guest_busy_reason(){
+  local conf="$1" node="$2" id="$3" lock
+  lock=$(awk '/^lock:/{print $2; exit}' "$conf" 2>/dev/null || true)
+  if [[ -n "$lock" ]]; then printf 'config lock "%s"' "$lock"; return 0; fi
+  # Server-side filter (--vmid) avoids 100-vs-1000 mismatches; --source active
+  # lists only running tasks. A "upid" in the output means one is in flight.
+  if pvesh get "/nodes/$node/tasks" --source active --vmid "$id" \
+       --output-format=json 2>/dev/null | grep -q '"upid"'; then
+    printf 'a running task'
+    return 0
+  fi
+  return 1
+}
+
+# Build RBD_POOL + RBD_ARGS for a storage id (handles external Ceph clusters).
+RBD_POOL=""; RBD_ARGS=()
+rbd_set_args(){
+  local st="$1" json monhost username
+  json=$(pvesh get /storage/"$st" --output-format=json 2>/dev/null || echo '{}')
+  RBD_POOL=$(grep -Po '"pool"\s*:\s*"\K[^"]+' <<<"$json" || echo "")
+  [[ -z "$RBD_POOL" ]] && RBD_POOL="rbd"
+  RBD_ARGS=(-p "$RBD_POOL")
+  monhost=$(grep -Po '"monhost"\s*:\s*"\K[^"]+' <<<"$json" || echo "")
+  username=$(grep -Po '"username"\s*:\s*"\K[^"]+' <<<"$json" || echo "")
+  if [[ -n "$monhost" ]]; then
+    RBD_ARGS+=(-m "${monhost// /,}")
+    [[ -n "$username" ]] && RBD_ARGS+=(--id "$username")
+    [[ -f "/etc/pve/priv/ceph/${st}.keyring" ]] && RBD_ARGS+=(--keyring "/etc/pve/priv/ceph/${st}.keyring")
+  fi
+}
+
+# Extract renamable volume/source tokens from a stream of config lines.
+_extract_vols(){
+  grep -E '^(scsi|ide|virtio|sata|nvme|efidisk|tpmstate|unused)[0-9]+:|^(rootfs|mp[0-9]+):' \
+    | grep -v -E '(none|\.iso)(,|$)' \
+    | sed -E 's/^[^:]+:[[:space:]]*//' \
+    | cut -d',' -f1
+}
+
+# True if a storage id is currently active (present in ACTIVE_STORAGES).
+storage_is_active(){ printf '%s\n' "${ACTIVE_STORAGES[@]}" | grep -qx "$1"; }
+
+# Abort the apply phase: roll everything back, restore HA, keep the old guest.
+WORK_CONF=""
+apply_fail(){
+  trap - ERR   # avoid re-entering this handler if a rollback step fails
+  local why="${1:-An error occurred during apply.}"
+  do_rollback
+  [[ -n "$WORK_CONF" && -e "$WORK_CONF" ]] && rm -f "$WORK_CONF"
+  restore_ha
+  log "ROLLED BACK: $why"
+  dialog --title "❌ Rename failed – rolled back" --msgbox "$why
+
+All changes were reverted. The guest remains as ID $ID_OLD." 12 72
+  clear
+  exit 1
+}
+
 ### 0) Must be root
 if [[ "$(id -u)" -ne 0 ]]; then
   echo "Please run as root!" >&2
@@ -64,8 +154,9 @@ if pvecm nodes &>/dev/null; then
   )
   log "Cluster nodes: ${CLUSTER_NODES[*]}"
 else
-  # Standalone mode: only the local host
-  THIS_NODE=$(hostname)
+  # Standalone mode: only the local host. Use the short name, which is what
+  # Proxmox uses as the node name in the API (a FQDN here would break lookups).
+  THIS_NODE=$(hostname -s)
   CLUSTER_NODES=("$THIS_NODE")
   log "Not in a cluster, using local node: $THIS_NODE"
 fi
@@ -119,8 +210,8 @@ while true; do
       continue
     fi
     # must be in Proxmox default range
-    if (( ID_OLD < 100 || ID_OLD > 1000000 )); then
-      dialog --msgbox "VMID must be between 100 and 1000000 (got $ID_OLD)." 6 50
+    if (( ID_OLD < 100 || ID_OLD > 999999999 )); then
+      dialog --msgbox "VMID must be between 100 and 999999999 (got $ID_OLD)." 6 50
       continue
     fi
     # -----------------------------
@@ -174,15 +265,21 @@ while true; do
   
   ### 4) Prompt for new VMID, show occupant and suggest next free ID
   while true; do
-    ID_NEW=$(dialog --stdout --inputbox "Enter new free VMID:" 8 40) || exit 1
+    # ESC / Cancel here goes BACK to the current-VMID prompt instead of killing
+    # the whole script, so a mistyped source VMID can be corrected.
+    if ! ID_NEW=$(dialog --stdout --cancel-label "Back" \
+                  --inputbox "Enter new free VMID (ESC = back):" 8 50); then
+      log "User went back from the new-VMID prompt"
+      continue 2
+    fi
     # --- sanitize & validate ---
     ID_NEW=${ID_NEW//[$'\t\r\n ']/}
     if ! [[ $ID_NEW =~ ^[0-9]+$ ]]; then
       dialog --msgbox "Invalid VMID ‘$ID_NEW’: only digits are allowed." 6 50
       continue
     fi
-    if (( ID_NEW < 100 || ID_NEW > 1000000 )); then
-      dialog --msgbox "VMID must be between 100 and 1000000 (got $ID_NEW)." 6 50
+    if (( ID_NEW < 100 || ID_NEW > 999999999 )); then
+      dialog --msgbox "VMID must be between 100 and 999999999 (got $ID_NEW)." 6 50
       continue
     fi
     # -----------------------------
@@ -207,10 +304,12 @@ while true; do
     done
   
     if $OCCUPIED; then
-      # extract the existing VM/CT name
+      # extract the existing VM/CT name (QEMU exposes "name", LXC "hostname")
+      if [[ "$TYPE_OCC" == lxc ]]; then OCC_KEY=hostname; else OCC_KEY=name; fi
       NAME_OCC=$(pvesh get "/nodes/$NODE_OCC/$TYPE_OCC/$ID_NEW/config" \
                  --output-format=json \
-               | grep -Po '"name"\s*:\s*"\K[^"]+' || echo "unknown")
+               | grep -Po "\"${OCC_KEY}\"\\s*:\\s*\"\\K[^\"]+" || echo "unknown")
+      [[ -z "$NAME_OCC" ]] && NAME_OCC="unknown"
   
       # find next free ID
       NEXT=$((ID_NEW + 1))
@@ -254,168 +353,220 @@ while true; do
   ### 6) Retrieve VM/LXC name from config
   if [[ "$TYPE" == "qemu" ]]; then
     # QEMU expose le nom sous "name:"
-    NAME=$(grep -E '^name:' "$CONF_PATH" | head -n1 | awk '{print $2}' || echo "unknown")
+    NAME=$(awk '/^name:/{print $2; exit}' "$CONF_PATH")
   else
     # LXC expose le nom sous "hostname:"
-    NAME=$(grep -E '^hostname:' "$CONF_PATH" | head -n1 | awk '{print $2}' || echo "unknown")
+    NAME=$(awk '/^hostname:/{print $2; exit}' "$CONF_PATH")
   fi
+  [[ -z "$NAME" ]] && NAME="unknown"
   log "Instance name: $NAME"
   
-  ### 7) Stop instance if needed
-  if [[ "$TYPE" == qemu ]]; then
-    STATE=$(qm status "$ID_OLD" 2>/dev/null | awk '{print $2}')
-  else
-    STATE=$(pct status "$ID_OLD" 2>/dev/null | awk '{print $2}')
-  fi
-  log "Raw status: $STATE"
-  if [[ "$STATE" != stopped ]]; then
-    dialog --yesno "Instance is '$STATE'. Stop it?" 7 50 && {
-      log "Stopping $TYPE $ID_OLD"
-      if [[ "$TYPE" == qemu ]]; then qm shutdown "$ID_OLD"; else pct shutdown "$ID_OLD"; fi
-      for i in {1..20}; do
-        sleep 3
-        if [[ "$TYPE" == qemu ]]; then
-          STATE=$(qm status "$ID_OLD" 2>/dev/null | awk '{print $2}')
-        else
-          STATE=$(pct status "$ID_OLD" 2>/dev/null | awk '{print $2}')
-        fi
-        [[ "$STATE" == stopped ]] && break
-      done
-      if [[ "$STATE" != stopped ]]; then
-        dialog --msgbox "Failed to stop." 6 40
-        clear
-        exit 1
-      fi
-      log "Instance stopped"
-    } || exit 1
-  fi
+  ### 7) Active storages (the instance is stopped later, only after the
+  ###    summary is confirmed, so an aborted run never leaves it stopped)
+  # Only storages whose Status column is "active" count as online; an enabled
+  # but unreachable storage shows up as "inactive" and must NOT pass the gate.
+  mapfile -t ACTIVE_STORAGES < <(pvesm status 2>/dev/null | awk 'NR>1 && $3=="active" {print $1}')
+  log "Active storages: ${ACTIVE_STORAGES[*]:-none}"
   
-  ### 8) Active storages
-  mapfile -t ACTIVE_STORAGES < <(pvesm status | awk 'NR>1 {print $1}')
-  log "Storages: ${ACTIVE_STORAGES[*]}"
-  
-  ### 9) Gather block volumes from the main section (exclude CD-ROMs)
-  mapfile -t VOL_OLD < <(
-    sed '/^\[/{q}' "$CONF_PATH" \
-      | grep -E '^(scsi|ide|virtio|sata|efidisk|tpmstate|unused)[0-9]+:|^(rootfs|mp[0-9]+):' \
-      | grep -v ',media=cdrom' \
-      | sed -E 's/^[^:]+:[[:space:]]*//' \
-      | cut -d',' -f1
-  )
-  log "Raw volumes (excluding CD-ROM): ${VOL_OLD[*]}"
-  
-  ### 9.a) Verify each disk actually exists (LVM, ZFS or file-based)
-  for vol in "${VOL_OLD[@]}"; do
-    st=${vol%%:*}
-    rel=${vol#*:}
+  ### 8) Gather block volumes
+  #   - exclude empty drives ("none") and ISO images (".iso") so install
+  #     CD-ROMs are ignored, but KEEP cloud-init drives (usually media=cdrom).
+  #   - nvme[0-9]+ is listed pre-emptively for future Proxmox bus support.
+  #   - "main section" = currently attached devices (MUST exist);
+  #     "whole file"   = also catches disks only referenced by a snapshot.
+  mapfile -t MAIN_RAW < <(sed '/^\[/{q}' "$CONF_PATH" | _extract_vols)
+  mapfile -t ALL_RAW  < <(_extract_vols < "$CONF_PATH")
 
-    # fetch storage info
-    st_json=$(pvesh get /storage/"$st" --output-format=json 2>/dev/null) || st_json="{}"
-    st_type=$(grep -Po '"type"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
-
-    if [[ "$st_type" =~ lvm ]]; then
-      # LVM: check logical volume
-      vg=$(grep -Po '"vgname"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
-      lv_name=${rel##*/}
-      if ! lvdisplay "$vg/$lv_name" &>/dev/null; then
-        dialog --title "❌ LVM volume not found" \
-               --msgbox "\
-Failed to locate LVM volume:
-  VG:    $vg
-  LV:    $lv_name
-
-Please verify the storage is online and the LV exists." 10 60
-        log "ERROR: Missing LVM volume $vg/$lv_name on $st"
-        clear; exit 1
-      fi
-
-    elif [[ "$st_type" == "zfspool" ]]; then
-      # ZFS: check dataset exists
-      pool=$(grep -Po '"pool"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
-      ds_name="${rel}"   # e.g. vm-302-disk-0
-      if ! zfs list "${pool}/${ds_name}" &>/dev/null; then
-        dialog --title "❌ ZFS dataset not found" \
-               --msgbox "\
-Failed to locate ZFS dataset:
-  Pool:    $pool
-  Dataset: ${pool}/${ds_name}
-
-Please verify the ZFS pool is available." 10 60
-        log "ERROR: Missing ZFS dataset ${pool}/${ds_name}"
-        clear; exit 1
-      fi
-
-    else
-      # file-based: check file under images/<VMID>
-      storage_path=$(grep -Po '"path"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
-      disk_file="$storage_path/images/$rel"
-      if [[ ! -e "$disk_file" ]]; then
-        dialog --title "❌ Disk file not found" \
-               --msgbox "\
-Failed to locate disk file on storage:
-  Storage: $st (path=$storage_path)
-  Expected file: $disk_file
-
-Please verify the filesystem is mounted and the file exists." 10 60
-        log "ERROR: Missing disk file $disk_file on $st"
-        clear; exit 1
-      fi
-    fi
-  done
-
-  log "All virtual disks exist, continuing…"
-  
-  ### 10) Gather vmstate entries from all snapshots
-  mapfile -t VMSTATE_OLD < <(
-    grep -E '^vmstate:' "$CONF_PATH" \
-      | sed -E 's/^vmstate:[[:space:]]*//' \
-      | cut -d',' -f1
-  )
-  log "Snapshot states: ${VMSTATE_OLD[*]}"
-  
-  ### 11) Gather snapshot section names
-  mapfile -t SNAP_SECTIONS < <(grep -Po '^\[\K[^\]]+' "$CONF_PATH")
-  log "Snapshot sections: ${SNAP_SECTIONS[*]}"
-  
-  ### 11.a) Gather existing LVM snapshot volumes
-  mapfile -t SNAP_LV_OLD < <(
-    lvs --noheadings -o lv_name,vg_name \
-      | awk '{print $1 ":" $2}' \
-      | grep "^snap_vm-${ID_OLD}-disk-"
-  )
-  log "Raw LVM snapshot volumes: ${SNAP_LV_OLD[*]}"
-  
-  ### 12) Classify volumes: LVM, ZFS, or file-based
-  LVM_OLD=()
-  ZFS_OLD=()
-  FILE_OLD=()
-  for vol in "${VOL_OLD[@]}"; do
-    st=${vol%%:*}; rel=${vol#*:}
-    # skip inactive storages
-    if ! printf '%s\n' "${ACTIVE_STORAGES[@]}" | grep -qx "$st"; then
-      log "Skipping volume $vol: storage '$st' not active"
+  # Real storage volumes ("storage:volume") vs bind/device mounts (host paths
+  # like mp0: /mnt/storage) and physical passthrough (ide2: cdrom).
+  BIND_MOUNTS_OLD=(); VOL_MAIN=()
+  declare -A _inmain=()
+  for vol in "${MAIN_RAW[@]}"; do
+    [[ -z "$vol" ]] && continue
+    if [[ "$vol" == /* || "$vol" != *:* ]]; then
+      BIND_MOUNTS_OLD+=("$vol")
+      log "Skipping bind/device mount $vol: not a Proxmox storage volume"
       continue
     fi
+    VOL_MAIN+=("$vol"); _inmain["$vol"]=1
+  done
+
+  VOL_SNAPONLY=()
+  declare -A _insnap=()
+  for vol in "${ALL_RAW[@]}"; do
+    [[ -z "$vol" ]] && continue
+    [[ "$vol" == /* || "$vol" != *:* ]] && continue
+    [[ -n "${_inmain[$vol]:-}" || -n "${_insnap[$vol]:-}" ]] && continue
+    VOL_SNAPONLY+=("$vol"); _insnap["$vol"]=1
+  done
+  unset _inmain _insnap
+
+  VOL_OLD=("${VOL_MAIN[@]}")
+  (( ${#VOL_SNAPONLY[@]} )) && VOL_OLD+=("${VOL_SNAPONLY[@]}")
+
+  # Membership string for quick "is this snapshot-only?" tests later.
+  SNAPONLY_SET=" ${VOL_SNAPONLY[*]:-} "
+
+  log "Attached storage volumes: ${VOL_MAIN[*]:-none}"
+  log "Snapshot-only volumes: ${VOL_SNAPONLY[*]:-none}"
+  log "Bind/device mounts skipped: ${BIND_MOUNTS_OLD[*]:-none}"
+
+  ### 9) vmstate volumes + snapshot section names
+  mapfile -t VMSTATE_OLD < <(
+    grep -E '^vmstate:' "$CONF_PATH" | sed -E 's/^vmstate:[[:space:]]*//' | cut -d',' -f1
+  )
+  mapfile -t SNAP_SECTIONS < <(grep -Po '^\[\K[^\]]+' "$CONF_PATH")
+  log "Snapshot states: ${VMSTATE_OLD[*]:-none}"
+  log "Snapshot sections: ${SNAP_SECTIONS[*]:-none}"
+
+  ### 9.0) GATE – every storage backing an attached disk or a vmstate volume
+  #         must be ONLINE. Renaming while a volume is on an offline/disabled
+  #         storage would leave the guest pointing at a disk that still owns
+  #         the old VMID, so we refuse and change nothing.
+  OFFLINE=()
+  for vol in "${VOL_MAIN[@]}" "${VMSTATE_OLD[@]}"; do
+    [[ -z "$vol" || "$vol" != *:* ]] && continue
+    st=${vol%%:*}
+    storage_is_active "$st" || OFFLINE+=("$st  ($vol)")
+  done
+  if (( ${#OFFLINE[@]} )); then
+    msg=$'This guest has a disk or saved state on an OFFLINE / disabled storage:\n\n'
+    for o in "${OFFLINE[@]}"; do msg+="  • $o"$'\n'; done
+    msg+=$'\nThat storage must be online so the volume can be renamed too;\notherwise the guest would break. Bring it online and retry.\n\nNothing was changed.'
+    dialog --title "❌ Storage offline – cannot rename safely" --msgbox "$msg" 16 74
+    log "ABORT: offline storage(s): ${OFFLINE[*]}"
+    continue
+  fi
+
+  ### 9.1) GATE – a TEMPLATE with linked clones cannot be renamed (renaming the
+  #         base volume breaks every linked clone that still references it).
+  if grep -qE '^template:[[:space:]]*1' "$CONF_PATH"; then
+    mapfile -t CLONE_REFS < <(
+      grep -rlE "base-${ID_OLD}-disk-[0-9]+/" \
+        /etc/pve/nodes/*/qemu-server/ /etc/pve/nodes/*/lxc/ 2>/dev/null \
+        | grep -v "/${ID_OLD}\.conf$" || true
+    )
+    if (( ${#CLONE_REFS[@]} )); then
+      msg=$'This guest is a TEMPLATE that still has linked clones:\n\n'
+      for c in "${CLONE_REFS[@]}"; do msg+="  • $c"$'\n'; done
+      msg+=$'\nRenaming it would break those clones. Convert them to full clones\nfirst, then retry. Nothing was changed.'
+      dialog --title "❌ Template has linked clones" --msgbox "$msg" 16 74
+      log "ABORT: template $ID_OLD has linked clones: ${CLONE_REFS[*]}"
+      continue
+    fi
+  fi
+
+  ### 9.2) GATE – existing replication jobs keep the old VMID on the target.
+  if [[ -f /etc/pve/replication.cfg ]] \
+     && grep -qE "^[[:alnum:]_-]+:[[:space:]]*${ID_OLD}-[0-9]+" /etc/pve/replication.cfg; then
+    dialog --title "❌ Replication configured" --msgbox "\
+This guest has one or more replication jobs.
+Renaming would desynchronise the replicated datasets on the target node(s).
+
+Remove the replication job(s) for VMID $ID_OLD first, then retry.
+Nothing was changed." 12 74
+    log "ABORT: replication jobs exist for $ID_OLD"
+    continue
+  fi
+
+  ### 9.4) GATE – the guest must be idle. An in-flight backup, migration,
+  #         snapshot, clone or disk-move holds a config lock; renaming while one
+  #         of those runs would corrupt it. Refuse while the guest is busy.
+  if reason=$(guest_busy_reason "$CONF_PATH" "$NODE_ASSIGNED" "$ID_OLD"); then
+    dialog --title "❌ Guest is busy" --msgbox "\
+This guest is currently busy ($reason).
+
+A backup, migration, snapshot, clone or disk move may be in progress.
+Wait for it to finish, or clear a stale lock with:
+    $( [[ "$TYPE" == qemu ]] && echo qm || echo pct ) unlock $ID_OLD
+then retry. Nothing was changed." 13 74
+    log "ABORT: guest $ID_OLD is busy ($reason)"
+    continue
+  fi
   
-    # fetch storage type
-    st_json=$(pvesh get /storage/"$st" --output-format=json 2>/dev/null || echo '{}')
-    stype=$(grep -Po '"type"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
-  
-    if [[ "$stype" =~ lvm ]]; then
-      LVM_OLD+=("$vol")
-    elif [[ "$stype" == "zfspool" ]]; then
-      ZFS_OLD+=("$vol")
+  ### 9.3) Verify each volume exists. Attached volumes are a HARD requirement
+  #         (abort if missing); snapshot-only volumes are best-effort (warn).
+  ok=true
+  for vol in "${VOL_OLD[@]}"; do
+    st=${vol%%:*}; rel=${vol#*:}
+    soft=false
+    case "$SNAPONLY_SET" in *" $vol "*) soft=true ;; esac
+
+    st_json=$(pvesh get /storage/"$st" --output-format=json 2>/dev/null) || st_json="{}"
+    st_type=$(grep -Po '"type"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
+    found=true
+    if [[ "$st_type" =~ lvm ]]; then
+      vg=$(grep -Po '"vgname"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
+      lvdisplay "$vg/${rel##*/}" &>/dev/null || found=false
+    elif [[ "$st_type" == "zfspool" ]]; then
+      pool=$(grep -Po '"pool"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
+      zfs list "${pool}/${rel##*/}" &>/dev/null || found=false
+    elif [[ "$st_type" == "rbd" ]]; then
+      # also proves the rbd CLI can reach the cluster (needed for the rename)
+      rbd_set_args "$st"
+      rbd "${RBD_ARGS[@]}" info "$rel" &>/dev/null || found=false
     else
-      FILE_OLD+=("$vol")
+      sp=$(grep -Po '"path"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
+      [[ -n "$sp" && -e "$sp/images/$rel" ]] || found=false
+    fi
+
+    if ! $found; then
+      if $soft; then
+        log "⚠️  Snapshot-only volume not found, will skip: $vol"
+      else
+        dialog --title "❌ Volume not found / unreachable" --msgbox "\
+Could not locate (or reach) a volume backing the guest:
+
+  $vol   (storage type: ${st_type:-unknown})
+
+Verify the storage is online and the volume exists.
+Nothing was changed." 12 74
+        log "ABORT: missing/unreachable volume $vol"
+        ok=false; break
+      fi
     fi
   done
-  mapfile -t FILE_OLD < <(printf "%s\n" "${FILE_OLD[@]}" | sort -u)
+  $ok || continue
+  log "All attached volumes verified."
+
+  ### 10) Existing LVM snapshot volumes (snap_vm-<id>-…)
+  mapfile -t SNAP_LV_OLD < <(
+    lvs --noheadings -o lv_name,vg_name 2>/dev/null \
+      | awk '{print $1 ":" $2}' | grep "^snap_vm-${ID_OLD}-" || true
+  )
+  log "LVM snapshot volumes: ${SNAP_LV_OLD[*]:-none}"
+
+  ### 11) Classify volumes: LVM / ZFS / RBD / file-based
+  LVM_OLD=(); ZFS_OLD=(); RBD_OLD=(); FILE_OLD=()
+  for vol in "${VOL_OLD[@]}"; do
+    st=${vol%%:*}
+    st_json=$(pvesh get /storage/"$st" --output-format=json 2>/dev/null || echo '{}')
+    stype=$(grep -Po '"type"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
+    if   [[ "$stype" =~ lvm ]];       then LVM_OLD+=("$vol")
+    elif [[ "$stype" == "zfspool" ]]; then ZFS_OLD+=("$vol")
+    elif [[ "$stype" == "rbd" ]];     then RBD_OLD+=("$vol")
+    else                                   FILE_OLD+=("$vol")
+    fi
+  done
+  (( ${#FILE_OLD[@]} )) && mapfile -t FILE_OLD < <(printf "%s\n" "${FILE_OLD[@]}" | sort -u)
+  log "LVM: ${LVM_OLD[*]:-none} | ZFS: ${ZFS_OLD[*]:-none} | RBD: ${RBD_OLD[*]:-none} | FILE: ${FILE_OLD[*]:-none}"
+
+  ### 11.a) Detect HA membership (only previewed now; disabled after confirm)
+  if [[ "$TYPE" == qemu ]]; then HA_PREFIX=vm; else HA_PREFIX=ct; fi
+  HA_MANAGED=false; HA_STATE=started; HA_SID=""
+  if command -v ha-manager &>/dev/null \
+     && grep -qE "^[[:space:]]*${HA_PREFIX}:[[:space:]]*${ID_OLD}([^0-9]|$)" /etc/pve/ha/resources.cfg 2>/dev/null; then
+    HA_MANAGED=true
+    HA_STATE=$(awk -v p="$HA_PREFIX" -v id="$ID_OLD" '
+      $0 ~ "^[[:space:]]*"p":[[:space:]]*"id"([^0-9]|$)" {blk=1; next}
+      blk && /^[^[:space:]]/ {blk=0}
+      blk && $1=="state" {print $2; exit}
+    ' /etc/pve/ha/resources.cfg)
+    [[ -z "$HA_STATE" ]] && HA_STATE=started
+    log "Guest is HA-managed (${HA_PREFIX}:$ID_OLD, state=$HA_STATE)"
+  fi
   
-  log "LVM volumes: ${LVM_OLD[*]}"
-  log "ZFS volumes: ${ZFS_OLD[*]}"
-  log "File volumes: ${FILE_OLD[*]}"
-  
-  ### 13) Gather backups
+  ### 11.b) Gather backups
   BKDIRS=(/var/lib/vz/dump /mnt/pve/*/dump)
   BK_OLD=()
   for d in "${BKDIRS[@]}"; do
@@ -425,8 +576,22 @@ Please verify the filesystem is mounted and the file exists." 10 60
       < <(find "$d" -type f -name "*-${ID_OLD}-*" 2>/dev/null)
   done
   log "Backups found: ${#BK_OLD[@]} files"
+
+  ### 11.c) Detect Proxmox Backup Server (PBS) snapshots for this guest.
+  #          PBS backups are immutable, content-addressed snapshots indexed by
+  #          VMID inside the datastore; they cannot be "mv"-renamed like file
+  #          dumps, so we only DETECT and WARN — they keep the old VMID.
+  mapfile -t PBS_STORAGES < <(pvesm status 2>/dev/null | awk 'NR>1 && $2=="pbs" {print $1}')
+  PBS_BK_OLD=()
+  for st in "${PBS_STORAGES[@]:-}"; do
+    [[ -z "$st" ]] && continue
+    while IFS= read -r volid; do
+      [[ -n "$volid" ]] && PBS_BK_OLD+=("$st:$volid")
+    done < <(pvesm list "$st" --vmid "$ID_OLD" 2>/dev/null | awk 'NR>1 {print $1}')
+  done
+  log "PBS snapshots found for $ID_OLD: ${#PBS_BK_OLD[@]}"
   
-  ### 14) Build summary
+  ### 12) Build summary
   SUMMARY=/tmp/rename_summary.txt
   :> "$SUMMARY"
   {
@@ -437,205 +602,370 @@ Please verify the filesystem is mounted and the file exists." 10 60
     echo; echo "• ZFS volumes:"
     for vol in "${ZFS_OLD[@]}"; do
       st=${vol%%:*}; oldds=${vol#*:}
-      newds="${oldds//$ID_OLD/$ID_NEW}"
+      child="${oldds##*/}"; newchild="${child//$ID_OLD/$ID_NEW}"
+      if [[ "$oldds" == */* ]]; then newds="${oldds%/*}/${newchild}"; else newds="$newchild"; fi
       echo "    $st: $oldds → $newds"
+    done
+    echo; echo "• RBD volumes:"
+    for vol in "${RBD_OLD[@]}"; do
+      st=${vol%%:*}; oldrbd=${vol#*:}
+      echo "    $st: $oldrbd → ${oldrbd//$ID_OLD/$ID_NEW}"
     done
     echo; echo "• LVM volumes:"
     for vol in "${LVM_OLD[@]}"; do
       st=${vol%%:*}; oldlv=${vol#*:}
-      vg=$(pvesh get /storage/"$st" --output-format=json \
-           | grep -Po '"vgname"\s*:\s*"\K[^"]+' || echo "")
-      if [[ -n "$vg" ]]; then
-        echo "    $vg/$oldlv → $vg/vm-${ID_NEW}-disk-${oldlv##*-}"
-      fi
+      echo "    $st: $oldlv → ${oldlv//$ID_OLD/$ID_NEW}"
     done
-      echo; echo "• LVM snapshots:"
-    mapfile -t SNAP_LV_OLD < <(
-      lvs --noheadings -o lv_name,vg_name \
-        | awk '{print $1 ":" $2}' \
-        | grep "^snap_vm-${ID_OLD}-disk-"
-    )
+    echo; echo "• LVM snapshot volumes:"
     for entry in "${SNAP_LV_OLD[@]}"; do
       old_snap=${entry%%:*}; vg=${entry#*:}
-      suffix=${old_snap#snap_vm-${ID_OLD}-disk-}
-      echo "    $vg/$old_snap → $vg/snap_vm-${ID_NEW}-disk-${suffix}"
+      echo "    $vg/$old_snap → $vg/${old_snap//$ID_OLD/$ID_NEW}"
     done
-    echo; echo "• Disques et points de montage (file-based):"
+    echo; echo "• File-based volumes:"
     for vf in "${FILE_OLD[@]}"; do
-      echo "    $vf"
+      echo "    $vf → ${vf//$ID_OLD/$ID_NEW}"
     done
-    echo; echo "• Snapshots (sections):"
+    if (( ${#VOL_SNAPONLY[@]} )); then
+      echo; echo "• Snapshot-only volumes (renamed if still present):"
+      for v in "${VOL_SNAPONLY[@]}"; do echo "    $v → ${v//$ID_OLD/$ID_NEW}"; done
+    fi
+    if (( ${#BIND_MOUNTS_OLD[@]} )); then
+      echo; echo "• Bind/device mount points (left untouched):"
+      for bm in "${BIND_MOUNTS_OLD[@]}"; do echo "    $bm"; done
+    fi
+    echo; echo "• Snapshot sections:"
     for s in "${SNAP_SECTIONS[@]}"; do echo "    [$s]"; done
-    echo; echo "• VMSTATE entries:"
+    echo; echo "• vmstate entries:"
     for s in "${VMSTATE_OLD[@]}"; do echo "    $s → ${s//$ID_OLD/$ID_NEW}"; done
-    echo; echo "• Backups:"
-    for f in "${BK_OLD[@]}"; do echo "    $f → ${f//-$ID_OLD-/-$ID_NEW-}"; done
+    echo; echo "• Backups (local dumps – renamed):"
+    for f in "${BK_OLD[@]}"; do
+      b=$(basename "$f"); echo "    $b → ${b//-$ID_OLD-/-$ID_NEW-}"
+    done
+    if (( ${#PBS_BK_OLD[@]} )); then
+      echo; echo "• ⚠️  PBS backups (NOT renamed – they will keep VMID $ID_OLD):"
+      for v in "${PBS_BK_OLD[@]}"; do echo "    $v"; done
+      echo "    → restore/prune these manually if you need them under $ID_NEW."
+    fi
     echo; echo "• jobs.cfg & replication.cfg:"
     for f in /etc/pve/jobs.cfg /etc/pve/replication.cfg; do
-      [[ -f "$f" ]] && grep -q "vmid.*\b$ID_OLD\b" "$f" \
+      [[ -f "$f" ]] && grep -qE "\bvmid[[:space:]]+$ID_OLD\b" "$f" \
         && echo "    $f: vmid $ID_OLD → $ID_NEW"
     done
-    echo; echo "• Pools & ACL (/etc/pve/user.cfg):"
-    echo "    Global replace '$ID_OLD' → '$ID_NEW'"
+    echo; echo "• Pools & ACL (/etc/pve/user.cfg): acl/pool lines, $ID_OLD → $ID_NEW"
+    echo; echo "• HA & firewall:"
+    $HA_MANAGED && echo "    HA resource: ${HA_PREFIX}:$ID_OLD → ${HA_PREFIX}:$ID_NEW (state=$HA_STATE; disabled during rename)"
+    [[ -f "/etc/pve/firewall/${ID_OLD}.fw" ]] && echo "    Firewall: ${ID_OLD}.fw → ${ID_NEW}.fw"
   } >> "$SUMMARY"
-  fold -s -w $(( $(tput cols)-4 )) "$SUMMARY" > "${SUMMARY}.wrapped"
+  # tput can return nothing without a proper TTY/TERM, which would yield a
+  # negative width and abort the script under "set -e"; fall back to 80x24.
+  TERM_COLS=$(tput cols 2>/dev/null || true);  [[ "$TERM_COLS"  =~ ^[0-9]+$ ]] || TERM_COLS=80
+  TERM_LINES=$(tput lines 2>/dev/null || true); [[ "$TERM_LINES" =~ ^[0-9]+$ ]] || TERM_LINES=24
+  fold -s -w $(( TERM_COLS-4 )) "$SUMMARY" > "${SUMMARY}.wrapped"
   
-  ### 15) Show summary & confirm
+  ### 13) Show summary & confirm
   dialog --title "Summary before apply" \
-         --textbox "${SUMMARY}.wrapped" $(( $(tput lines)-4 )) $(( $(tput cols)-4 ))
-  dialog --yesno "Apply changes?" 8 50 || { log "Aborted"; exit 1; }
+         --textbox "${SUMMARY}.wrapped" $(( TERM_LINES-4 )) $(( TERM_COLS-4 ))
+  dialog --yesno "Apply changes?" 8 50 || { log "Aborted by user (nothing changed)"; continue; }
   log "User confirmed apply"
-  
-  ### 16) Execute renaming
-  log "Applying changes…"
-  
-  # 16.a) Config
-  if [[ -e "$CONF_PATH" ]]; then
-    mv "$CONF_PATH" "$CONF_DIR/$ID_NEW.conf"
-    log "Config: $CONF_PATH → $CONF_DIR/$ID_NEW.conf"
-  else
-    log "⚠️  Config not found, skipped: $CONF_PATH"
+
+  ### 14) Neutralize HA so the CRM cannot restart the guest mid-rename
+  if $HA_MANAGED; then
+    if ha-manager set "${HA_PREFIX}:$ID_OLD" --state disabled &>/dev/null; then
+      HA_SID="${HA_PREFIX}:$ID_OLD"
+      log "HA ${HA_PREFIX}:$ID_OLD set to disabled (will restore state=$HA_STATE)"
+    else
+      log "⚠️  Could not disable HA ${HA_PREFIX}:$ID_OLD"
+    fi
   fi
-  
-  # 16.b) Rename LVM volumes
-  for vol in "${LVM_OLD[@]}"; do
-    st=${vol%%:*}; oldlv=${vol#*:}
-    vg=$(pvesh get /storage/"$st" --output-format=json \
-         | grep -Po '"vgname"\s*:\s*"\K[^"]+' || echo "")
-    newlv="vm-${ID_NEW}-disk-${oldlv##*-}"
-    if [[ -n "$vg" ]]; then
-      lvrename "$vg" "$oldlv" "$newlv"
-      sed -i "s|$st:$oldlv|$st:$newlv|g" "$CONF_DIR/$ID_NEW.conf"
-      log "LVM: $vg/$oldlv → $vg/$newlv"
+
+  ### 15) Stop the instance if needed
+  if [[ "$TYPE" == qemu ]]; then STATE=$(qm status "$ID_OLD" 2>/dev/null | awk '{print $2}')
+  else STATE=$(pct status "$ID_OLD" 2>/dev/null | awk '{print $2}'); fi
+  log "Status: ${STATE:-unknown}"
+  if [[ "$STATE" != stopped ]]; then
+    if dialog --yesno "Instance is '${STATE:-unknown}'. Stop it now?" 7 50; then
+      log "Stopping $TYPE $ID_OLD"
+      if [[ "$TYPE" == qemu ]]; then qm shutdown "$ID_OLD" || true; else pct shutdown "$ID_OLD" || true; fi
+      for i in {1..20}; do
+        sleep 3
+        if [[ "$TYPE" == qemu ]]; then STATE=$(qm status "$ID_OLD" 2>/dev/null | awk '{print $2}')
+        else STATE=$(pct status "$ID_OLD" 2>/dev/null | awk '{print $2}'); fi
+        [[ "$STATE" == stopped ]] && break
+      done
+      if [[ "$STATE" != stopped ]]; then
+        dialog --msgbox "Failed to stop the instance. Aborting (nothing changed)." 6 55
+        log "ABORT: failed to stop $ID_OLD"
+        restore_ha
+        continue
+      fi
+      log "Instance stopped"
+    else
+      log "User declined to stop; aborting (nothing changed)"
+      restore_ha
+      continue
+    fi
+  fi
+
+  ### 15.5) Re-check the target VMID is still free (it was validated back in
+  #          step 4; another node/admin/CRM may have claimed it since then).
+  for N in "${CLUSTER_NODES[@]}"; do
+    if pvesh get "/nodes/$N/qemu/$ID_NEW/config" &>/dev/null \
+       || pvesh get "/nodes/$N/lxc/$ID_NEW/config" &>/dev/null; then
+      dialog --msgbox "VMID $ID_NEW was taken in the meantime (node $N). Aborting (nothing changed)." 7 60
+      log "ABORT: target VMID $ID_NEW became occupied on $N before apply"
+      restore_ha
+      continue 2
     fi
   done
+
+  # Re-check the guest is still idle: a backup/snapshot/clone may have grabbed a
+  # lock between the summary confirmation and now. Abort cleanly if so.
+  if reason=$(guest_busy_reason "$CONF_PATH" "$NODE_ASSIGNED" "$ID_OLD"); then
+    dialog --msgbox "Guest became busy ($reason) before apply. Aborting (nothing changed)." 7 60
+    log "ABORT: guest $ID_OLD became busy ($reason) before apply"
+    restore_ha
+    continue 2
+  fi
+
+  ### 16) Execute renaming (transactional: rename volumes, edit a working copy
+  #        of the config, then commit; on any failure roll everything back)
+  log "Applying changes…"
+  ROLLBACK=()
+  # From here until the commit (16.f) any unguarded command failure must roll
+  # everything back and restore HA, so route "set -e" errors through apply_fail.
+  trap 'apply_fail "Unexpected error during apply"' ERR
+  WORK_CONF=$(mktemp)
+  cp "$CONF_PATH" "$WORK_CONF" || apply_fail "Could not create a working copy of the config"
+
+  # 16.a) The config is committed only at the very end (16.f). Until then every
+  #        edit targets "$WORK_CONF" and the live $ID_OLD.conf stays intact, so a
+  #        rollback simply discards the working copy and reverts the volumes.
+
+  # 16.b) Rename LVM volumes. Replacing the VMID inside the name preserves the
+  #        convention Proxmox encodes there (vm-/base-/…-cloudinit).
+  for vol in "${LVM_OLD[@]}"; do
+    st=${vol%%:*}; oldlv=${vol#*:}
+    newlv="${oldlv//$ID_OLD/$ID_NEW}"
+    [[ "$oldlv" == "$newlv" ]] && { sed -i "s|$st:$oldlv|$st:$newlv|g" "$WORK_CONF"; continue; }
+    vg=$(pvesh get /storage/"$st" --output-format=json | grep -Po '"vgname"\s*:\s*"\K[^"]+' || echo "")
+    [[ -z "$vg" ]] && apply_fail "No volume group found for storage $st"
+    lvdisplay "$vg/$oldlv" &>/dev/null || { log "⚠️  LVM $vg/$oldlv missing, skipped"; continue; }
+    lvrename "$vg" "$oldlv" "$newlv" || apply_fail "lvrename $vg/$oldlv → $newlv failed"
+    push_rollback "lvrename '$vg' '$newlv' '$oldlv'"
+    sed -i "s|$st:$oldlv|$st:$newlv|g" "$WORK_CONF"
+    log "LVM: $vg/$oldlv → $vg/$newlv"
+  done
   
-  # 16.b bis) Rename LVM snapshot volumes
+  # 16.b bis) Rename LVM snapshot volumes (snap_vm-<id>-… , any suffix)
   mapfile -t SNAP_LV_OLD < <(
-    lvs --noheadings -o lv_name,vg_name \
-      | awk '{print $1 ":" $2}' \
-      | grep "^snap_vm-${ID_OLD}-disk-"
+    lvs --noheadings -o lv_name,vg_name 2>/dev/null \
+      | awk '{print $1 ":" $2}' | grep "^snap_vm-${ID_OLD}-" || true
   )
   for entry in "${SNAP_LV_OLD[@]}"; do
-    old_snap=${entry%%:*}
-    vg=${entry#*:}
-    suffix=${old_snap#snap_vm-${ID_OLD}-disk-}
-    new_snap="snap_vm-${ID_NEW}-disk-${suffix}"
-  
+    old_snap=${entry%%:*}; vg=${entry#*:}
+    new_snap="${old_snap//$ID_OLD/$ID_NEW}"
+    [[ "$old_snap" == "$new_snap" ]] && continue
     if lvdisplay "$vg/$old_snap" &>/dev/null; then
-      lvrename "$vg" "$old_snap" "$new_snap"
+      lvrename "$vg" "$old_snap" "$new_snap" || apply_fail "lvrename snapshot $vg/$old_snap failed"
+      push_rollback "lvrename '$vg' '$new_snap' '$old_snap'"
       log "LVM snapshot: $vg/$old_snap → $vg/$new_snap"
     else
       log "⚠️  Snapshot $vg/$old_snap not found, skipped"
     fi
   done
-  
-  # Update any references in the new config file
-  sed -i "s/snap_vm-${ID_OLD}-disk-/snap_vm-${ID_NEW}-disk-/g" "$CONF_DIR/$ID_NEW.conf"
+
+  # Update snapshot-volume references in the working config copy
+  sed -i "s/snap_vm-${ID_OLD}-/snap_vm-${ID_NEW}-/g" "$WORK_CONF"
   
   # 16.c) Rename ZFS volumes
-  # Build a map of storage ID → zfs pool
-  declare -A ZFS_POOL
+  declare -A ZFS_POOL=()
   for st in $(printf '%s\n' "${ZFS_OLD[@]}" | cut -d: -f1 | sort -u); do
-    ZFS_POOL[$st]=$(pvesh get /storage/"$st" --output-format=json \
-                    | grep -Po '"pool"\s*:\s*"\K[^"]+' )
+    ZFS_POOL[$st]=$(pvesh get /storage/"$st" --output-format=json | grep -Po '"pool"\s*:\s*"\K[^"]+' || echo "")
   done
 
-  # Loop over each ZFS volume and rename it
   for vol in "${ZFS_OLD[@]}"; do
-    st=${vol%%:*}            # storage ID, e.g. SCSI3-ZFS
-    rel=${vol#*:}            # dataset name, e.g. vm-302-disk-0
+    st=${vol%%:*}; rel=${vol#*:}
+    pool=${ZFS_POOL[$st]:-}
+    [[ -z "$pool" ]] && apply_fail "No ZFS pool found for storage $st"
 
-    pool=${ZFS_POOL[$st]}
-    old_ds="${pool}/${rel}"
-    newrel="${rel//$ID_OLD/$ID_NEW}"
-    new_ds="${pool}/${newrel}"
+    # Linked clones use a composite volid "base-…/vm-…"; only the child (after
+    # the last '/') is a real dataset, the parent base must stay untouched.
+    child="${rel##*/}"; newchild="${child//$ID_OLD/$ID_NEW}"
+    if [[ "$rel" == */* ]]; then newrel="${rel%/*}/${newchild}"; else newrel="$newchild"; fi
 
-    # perform the zfs rename
-    if ! zfs rename "$old_ds" "$new_ds"; then
-      log "ERROR: Failed to rename ZFS dataset from $old_ds to $new_ds"
-      exit 1
+    if [[ "$child" == "$newchild" ]]; then
+      sed -i "s|$st:$rel|$st:$newrel|g" "$WORK_CONF"; continue
     fi
+    if ! zfs list "$pool/$child" &>/dev/null; then
+      log "⚠️  ZFS $pool/$child missing, skipped"; continue
+    fi
+    zfs rename "$pool/$child" "$pool/$newchild" || apply_fail "zfs rename $pool/$child failed"
+    push_rollback "zfs rename '$pool/$newchild' '$pool/$child'"
 
-    # update config to reference the new dataset
-    sed -i "s|$st:$rel|$st:$newrel|g" "$CONF_DIR/$ID_NEW.conf"
-
-    log "ZFS: $old_ds → $new_ds"
+    # If an explicit mountpoint still carries the old id, update it as well.
+    mp=$(zfs get -H -o value mountpoint "$pool/$newchild" 2>/dev/null || echo "")
+    if [[ -n "$mp" && "$mp" != none && "$mp" != legacy && "$mp" == *"$ID_OLD"* ]]; then
+      newmp="${mp//$ID_OLD/$ID_NEW}"
+      if zfs set mountpoint="$newmp" "$pool/$newchild" 2>/dev/null; then
+        push_rollback "zfs set mountpoint='$mp' '$pool/$newchild'"
+        log "ZFS mountpoint: $mp → $newmp"
+      fi
+    fi
+    sed -i "s|$st:$rel|$st:$newrel|g" "$WORK_CONF"
+    log "ZFS: $pool/$child → $pool/$newchild"
   done
 
-  # 16.d) Rename all file-based volumes in place, with correct images/ prefix
-  if (( ${#FILE_OLD[@]} > 0 )); then
-    declare -A ST_PATH
+  # 16.c bis) Rename Ceph/RBD images (block storage, no file under images/)
+  for vol in "${RBD_OLD[@]}"; do
+    st=${vol%%:*}; rel=${vol#*:}
+    newrel="${rel//$ID_OLD/$ID_NEW}"
+    [[ "$rel" == "$newrel" ]] && { sed -i "s|$st:$rel|$st:$newrel|g" "$WORK_CONF"; continue; }
+    rbd_set_args "$st"
+    rbd "${RBD_ARGS[@]}" info "$rel" &>/dev/null || { log "⚠️  RBD $RBD_POOL/$rel missing, skipped"; continue; }
+    rbd "${RBD_ARGS[@]}" rename "$rel" "$newrel" || apply_fail "rbd rename $RBD_POOL/$rel → $newrel failed"
+    push_rollback "rbd ${RBD_ARGS[*]} rename '$newrel' '$rel'"
+    sed -i "s|$st:$rel|$st:$newrel|g" "$WORK_CONF"
+    log "RBD: $RBD_POOL/$rel → $RBD_POOL/$newrel"
+  done
 
-    # Build a map of storage ID → storage path (use read to avoid word splitting & empty-iteration)
+  # 16.d) Rename file-based volumes in place (correct images/<vmid>/ prefix)
+  if (( ${#FILE_OLD[@]} > 0 )); then
+    declare -A ST_PATH=()
     while IFS= read -r st; do
       [[ -z "$st" ]] && continue
       ST_PATH[$st]=$(pvesh get /storage/"$st" --output-format=json 2>/dev/null \
                      | grep -Po '"path"\s*:\s*"\K[^"]+' || echo "")
     done < <(printf '%s\n' "${FILE_OLD[@]}" | cut -d: -f1 | sort -u)
 
-    # Loop over each file-based volume and rename it
     for vol in "${FILE_OLD[@]}"; do
-      st=${vol%%:*}           # storage ID
-      rel=${vol#*:}           # e.g. "302/vm-302-disk-0.qcow2"
+      st=${vol%%:*}; rel=${vol#*:}
       [[ -z "$st" ]] && continue
-
-      # Skip if storage path not found (avoids "bad array subscript" with set -u)
-      if [[ ! -v ST_PATH[$st] ]] || [[ -z "${ST_PATH[$st]}" ]]; then
-        log "⚠️  No path for storage '$st', skipped: $vol"
-        continue
-      fi
-      path="${ST_PATH[$st]}"
-
-      oldf="${path}/images/$rel"
-      newrel="${rel//$ID_OLD/$ID_NEW}"
-      newf="${path}/images/$newrel"
-
-      if [[ -e "$oldf" ]]; then
-        mkdir -p "$(dirname "$newf")"
-        mv "$oldf" "$newf"
-        sed -i "s|$st:$rel|$st:$newrel|g" "$CONF_DIR/$ID_NEW.conf"
-        log "File: $oldf → $newf"
-      else
-        log "⚠️  File not found, skipped: $oldf"
-      fi
+      path="${ST_PATH[$st]:-}"
+      [[ -z "$path" ]] && { log "⚠️  No path for storage '$st', skipped: $vol"; continue; }
+      oldf="$path/images/$rel"; newrel="${rel//$ID_OLD/$ID_NEW}"; newf="$path/images/$newrel"
+      [[ "$oldf" == "$newf" ]] && { sed -i "s|$st:$rel|$st:$newrel|g" "$WORK_CONF"; continue; }
+      [[ -e "$oldf" ]] || { log "⚠️  File not found, skipped: $oldf"; continue; }
+      [[ -e "$newf" ]] && apply_fail "Target file already exists: $newf"
+      mkdir -p "$(dirname "$newf")"
+      mv "$oldf" "$newf" || apply_fail "mv $oldf → $newf failed"
+      push_rollback "mv -- '$newf' '$oldf'"
+      sed -i "s|$st:$rel|$st:$newrel|g" "$WORK_CONF"
+      log "File: $oldf → $newf"
     done
   fi
+
+  # 16.e) Rename snapshot vmstate volumes (RAM state); these can sit on any
+  #        storage type and must follow the new VMID or rollback breaks.
+  for vol in "${VMSTATE_OLD[@]}"; do
+    [[ -z "$vol" || "$vol" != *:* ]] && continue
+    st=${vol%%:*}; rel=${vol#*:}; newrel="${rel//$ID_OLD/$ID_NEW}"
+    [[ "$rel" == "$newrel" ]] && { sed -i "s|$st:$rel|$st:$newrel|g" "$WORK_CONF"; continue; }
+    st_json=$(pvesh get /storage/"$st" --output-format=json 2>/dev/null || echo '{}')
+    stype=$(grep -Po '"type"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
+    case "$stype" in
+      *lvm*)
+        vg=$(grep -Po '"vgname"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
+        if [[ -n "$vg" ]] && lvdisplay "$vg/$rel" &>/dev/null; then
+          lvrename "$vg" "$rel" "$newrel" || apply_fail "vmstate lvrename $vg/$rel failed"
+          push_rollback "lvrename '$vg' '$newrel' '$rel'"
+          log "vmstate LVM: $vg/$rel → $vg/$newrel"
+        else log "⚠️  vmstate LVM $vg/$rel not found, skipped"; fi ;;
+      zfspool)
+        pool=$(grep -Po '"pool"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
+        if [[ -n "$pool" ]] && zfs list "$pool/$rel" &>/dev/null; then
+          zfs rename "$pool/$rel" "$pool/$newrel" || apply_fail "vmstate zfs rename $pool/$rel failed"
+          push_rollback "zfs rename '$pool/$newrel' '$pool/$rel'"
+          log "vmstate ZFS: $pool/$rel → $pool/$newrel"
+        else log "⚠️  vmstate ZFS $pool/$rel not found, skipped"; fi ;;
+      rbd)
+        rbd_set_args "$st"
+        if rbd "${RBD_ARGS[@]}" info "$rel" &>/dev/null; then
+          rbd "${RBD_ARGS[@]}" rename "$rel" "$newrel" || apply_fail "vmstate rbd rename $RBD_POOL/$rel failed"
+          push_rollback "rbd ${RBD_ARGS[*]} rename '$newrel' '$rel'"
+          log "vmstate RBD: $RBD_POOL/$rel → $RBD_POOL/$newrel"
+        else log "⚠️  vmstate RBD $RBD_POOL/$rel not found, skipped"; fi ;;
+      *)
+        sp=$(grep -Po '"path"\s*:\s*"\K[^"]+' <<<"$st_json" || echo "")
+        oldf="$sp/images/$rel"; newf="$sp/images/$newrel"
+        if [[ -n "$sp" && -e "$oldf" ]]; then
+          [[ -e "$newf" ]] && apply_fail "vmstate target already exists: $newf"
+          mkdir -p "$(dirname "$newf")"
+          mv "$oldf" "$newf" || apply_fail "vmstate mv $oldf failed"
+          push_rollback "mv -- '$newf' '$oldf'"
+          log "vmstate file: $oldf → $newf"
+        else log "⚠️  vmstate file $oldf not found, skipped"; fi ;;
+    esac
+    sed -i "s|$st:$rel|$st:$newrel|g" "$WORK_CONF"
+  done
+
+  # 16.f) COMMIT — write the new config, then drop the old one. This is the
+  #        point of no return; everything after is best-effort (logged only).
+  cp "$WORK_CONF" "$CONF_DIR/$ID_NEW.conf" || apply_fail "Failed to write $ID_NEW.conf"
+  rm -f "$WORK_CONF"; WORK_CONF=""
+  rm -f "$CONF_PATH"
+  ROLLBACK=()
+  # Point of no return reached: stop auto-rolling-back on errors, the rest is
+  # best-effort cleanup and must not undo the (now committed) rename.
+  trap - ERR
+  log "Config committed: $ID_OLD.conf → $ID_NEW.conf"
   
-  # 16.f) Move backups
+  # 16.g) Move backups — rename only the basename (never rewrite the directory
+  #        path) and never overwrite an existing target.
   for f in "${BK_OLD[@]}"; do
-    nf="${f//-$ID_OLD-/-$ID_NEW-}"
-    # Check if src and dest are exactly the same file path
-    if [[ "$f" == "$nf" ]]; then
-      log "Backup source and target are the same: $f (skipping)"
+    [[ -e "$f" ]] || { log "⚠️  Backup not found, skipped: $f"; continue; }
+    d=$(dirname "$f"); b=$(basename "$f"); nb="${b//-$ID_OLD-/-$ID_NEW-}"
+    [[ "$b" == "$nb" ]] && continue
+    nf="$d/$nb"
+    if [[ -e "$nf" ]]; then
+      log "⚠️  Backup target exists, skipped: $nf"
       continue
     fi
-    # Optional: also check inode (same file, hard link case)
-    if [[ -e "$nf" && "$(stat -c '%d:%i' "$f")" == "$(stat -c '%d:%i' "$nf")" ]]; then
-      log "Backup source and target are the same file (inode): $f (skipping)"
-      continue
-    fi
-    if [[ -e "$f" ]]; then
-      mv "$f" "$nf"
-      log "Backup: $f → $nf"
-    else
-      log "⚠️  Backup not found, skipped: $f"
-    fi
+    mv "$f" "$nf" && log "Backup: $f → $nf"
   done
   
-  # 16.g) Update jobs.cfg & replication.cfg
+  # 16.h) Update jobs.cfg & replication.cfg (only log when something changed)
   for f in /etc/pve/jobs.cfg /etc/pve/replication.cfg; do
-    if [[ -f "$f" ]]; then
+    if [[ -f "$f" ]] && grep -qE "\bvmid[[:space:]]+$ID_OLD\b" "$f"; then
       sed -i "s/\bvmid[[:space:]]\+$ID_OLD\b/vmid $ID_NEW/" "$f"
-      log "Updated vmid in $f"
+      log "Updated vmid $ID_OLD → $ID_NEW in $f"
     fi
   done
   
-  # 16.h) Pools & ACL
-  if sed -i "s/\b$ID_OLD\b/$ID_NEW/g" /etc/pve/user.cfg; then
-    log "Updated pools & ACL"
-  else
-    log "⚠️  Failed to update ACL (skipped)"
+  # 16.i) Pools & ACL — restrict the replacement to acl:/pool: lines so that
+  #        unrelated numeric fields or comments elsewhere are never touched.
+  if [[ -f /etc/pve/user.cfg ]]; then
+    if sed -i -E "/^(acl|pool):/ s/\b$ID_OLD\b/$ID_NEW/g" /etc/pve/user.cfg; then
+      log "Updated pools & ACL (acl/pool lines)"
+    else
+      log "⚠️  Failed to update ACL (skipped)"
+    fi
+  fi
+
+  # 16.j) HA: rename the sid in resources.cfg, then restore the original state
+  #        (the entry was set to 'disabled' before the rename).
+  if $HA_MANAGED; then
+    HA_CFG=/etc/pve/ha/resources.cfg
+    if [[ -f "$HA_CFG" ]]; then
+      sed -i -E "s/^([[:space:]]*${HA_PREFIX}:[[:space:]]*)$ID_OLD([^0-9]|$)/\1$ID_NEW\2/" "$HA_CFG"
+      log "HA resource ${HA_PREFIX}:$ID_OLD → ${HA_PREFIX}:$ID_NEW"
+    fi
+    if ha-manager set "${HA_PREFIX}:$ID_NEW" --state "$HA_STATE" &>/dev/null; then
+      log "HA restored: ${HA_PREFIX}:$ID_NEW state=$HA_STATE"
+    else
+      log "⚠️  Could not restore HA state for ${HA_PREFIX}:$ID_NEW"
+    fi
+    HA_SID=""   # handled; keep restore_ha() from touching the old sid
+  fi
+
+  # 16.k) Per-guest firewall rules (/etc/pve/firewall/<vmid>.fw)
+  FW_OLD="/etc/pve/firewall/${ID_OLD}.fw"
+  FW_NEW="/etc/pve/firewall/${ID_NEW}.fw"
+  if [[ -f "$FW_OLD" ]]; then
+    if [[ -e "$FW_NEW" ]]; then
+      log "⚠️  Firewall target exists, skipped: $FW_NEW"
+    else
+      mv "$FW_OLD" "$FW_NEW" && log "Firewall: $FW_OLD → $FW_NEW"
+    fi
   fi
   
   ### 17) Final message


### PR DESCRIPTION
## Summary

Major rework of the rename flow to make it safe for common production setups
(standalone or clustered PVE). The original config is never touched until every
volume rename has succeeded, and any failure is rolled back automatically.

## Highlights

### Transactional apply with rollback
- All volume renames are recorded on a rollback stack and undone automatically on failure.
- Edits target a working copy of the config; the live `<old>.conf` is only replaced at a single commit step, then the old file is removed (point of no return).
- An `ERR` trap routes any unexpected failure during apply through a clean rollback + HA restore, and is cleared once committed so post-commit cleanup never reverts.

### New pre-flight safety gates (abort cleanly, change nothing)
- Disk/vmstate on an **offline/disabled storage** (now keyed on `pvesm status == active`, not just "listed").
- **Template with linked clones**.
- Existing **replication job** for the guest.
- **Busy guest**: refuses while a config `lock:` or an active task (backup, migration, snapshot, clone, disk-move) is in flight — with a re-check just before apply.
- Target VMID re-verified free right before apply (TOCTOU).
- Per-volume existence check: hard requirement for attached disks, best-effort (warn) for snapshot-only volumes.

### Wider storage coverage
- **Ceph/RBD** rename support, including external clusters (pool/mon/keyring args).
- **ZFS**: rename only the child dataset of linked clones, and follow an explicit mountpoint carrying the old id.
- Rename snapshot **vmstate** (RAM state) volumes across LVM/ZFS/RBD/file.
- Detect **snapshot-only** volumes (whole-file scan) and **bind/device mounts** (left untouched — fixes #5).

### HA, backups & cluster metadata
- Detect HA membership, disable the resource during the rename, rename the SID and restore its original state.
- Detect **Proxmox Backup Server** snapshots and warn they keep the old VMID (immutable, not renamed).
- Local dump backups: rename basename only, never overwrite an existing target.
- Targeted updates to `jobs.cfg`/`replication.cfg`, `user.cfg` (acl/pool lines only) and per-guest firewall `<vmid>.fw`.

### Robustness & UX
- ESC on the new-VMID prompt goes back instead of killing the script.
- Fixed LXC occupant name lookup (`hostname`) and instance name parsing.
- Short hostname used for the standalone node name.
- VMID range aligned with Proxmox (100–999999999).
- Falls back to 80x24 when `tput` returns no size (non-TTY safety).
- Aborts now `continue` the main loop instead of exiting the whole session.
- ShellCheck clean-ups (SC2015, SC2034).

## Test plan
- [ ] LXC with `mp0` bind mount (left untouched)
- [X] QEMU on local-lvm (simple)
- [X] QEMU on ZFS (simple) and LXC rootfs on ZFS subvol
- [ ] VM with cloud-init drive
- [X] VM with snapshot + vmstate
- [ ] VM with per-guest firewall `.fw`
- [ ] HA-managed guest (disabled during rename, state restored after)
- [ ] Ceph/RBD volume (local and external cluster)
- [ ] Gates abort cleanly: offline storage, template w/ linked clones, replication job, busy/locked guest
- [ ] Rollback path (e.g. force an existing target volume) leaves the guest intact as the old VMID

## Notes
- PBS backups are intentionally **not** renamed (kept under the old VMID) and only reported.